### PR TITLE
Contour Counting Performance

### DIFF
--- a/Swift VectorBoolean/VectorBoolean/FBBezierGraph.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBBezierGraph.swift
@@ -1029,6 +1029,12 @@ class FBBezierGraph {
 
     var intersectCount = 0
     for contour in contours {
+        
+      // if the line starts and ends outside the bounds of a contour we can assume it's either 2 or 0 crossings so no need to count
+      // the test line should always end outside the bounds so just test the start point
+      if !contour.bounds.contains(testPoint) {
+        continue
+      }
 
       // LRT - Added test for empty contour added by Obj-C simulation
       if contour.edges.count == 0 {
@@ -1038,6 +1044,8 @@ class FBBezierGraph {
       if contour === testContour || contour.crossesOwnContour(testContour) {
         continue // don't test self intersections
       }
+        
+      
 
       intersectCount += contour.numberOfIntersectionsWithRay(testCurve)
     }
@@ -1065,8 +1073,15 @@ class FBBezierGraph {
         let lineEndPoint = CGPoint(x: beyondX, y: beyondY)
         let testCurve = FBBezierCurve(startPoint: testPoint, endPoint: lineEndPoint)
         
-        let intersectCount = isInsideContour.numberOfIntersectionsWithRay(testCurve)
-
+        let intersectCount:Int
+        
+        // if the line starts and ends outside the bounds of a contour we can assume it's either 2 or 0 crossings so no need to count
+        // the test line should always end outside the bounds so just test the start point
+        if isInsideContour.bounds.contains(testPoint) {
+            intersectCount = isInsideContour.numberOfIntersectionsWithRay(testCurve)
+        } else {
+            intersectCount = 2
+        }
         
         // return (intersectCount & 1) == 1 ? .Hole : .Filled
         if intersectCount.isOdd {

--- a/Swift VectorBoolean/VectorBoolean/FBBezierGraph.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBBezierGraph.swift
@@ -1044,8 +1044,6 @@ class FBBezierGraph {
       if contour === testContour || contour.crossesOwnContour(testContour) {
         continue // don't test self intersections
       }
-        
-      
 
       intersectCount += contour.numberOfIntersectionsWithRay(testCurve)
     }


### PR DESCRIPTION
This adds some shortcuts to improve perfromance of the contour counting and the contour splitting algorithm.

@natep mind taking a look at this and testing it with your unit tests? It seemed to work in a few test cases but it's not super thorough.

I think this is also still too slow to not do some other improvements. The problem shapes we're working with still take 6 seconds or so to initially select. Thats an improvement from 60, but I think we would still want to do you 20-shape complexity bail-out.